### PR TITLE
Merge Direct inverse to master branch

### DIFF
--- a/mmt_multipole_inversion/multipole_inversion.py
+++ b/mmt_multipole_inversion/multipole_inversion.py
@@ -353,7 +353,7 @@ class MultipoleInversion(object):
                 np_pinv  -> Numpy's pinv
                 sp_pinv  -> Scipy's pinv (not recommended -> memory issues)
                 sp_pinv2 -> Scipy's pinv2 (this will call sp_pinv instead)
-                direct   -> direct inverse (most memory efficient)
+                direct   -> direct inverse (quickest and most memory efficient)
         sigma_field_noise
             If a `float` is specified, a covariance matrix is produced and
             stored in the `covariance_matrix` variable. This matrix uses
@@ -381,7 +381,8 @@ class MultipoleInversion(object):
             Bz_Data = np.reshape(self.Bz_array, self.N_sensors, order='C')
             if self.verbose:
                 print('Using direct inversion')
-            self.inv_multipole_moments, res, rnk, s = slin.lstsq(self.Q, Bz_Data)
+            self.inv_multipole_moments, res, rnk, s = slin.lstsq(
+                self.Q, Bz_Data, **method_kwargs)
             self.inv_multipole_moments.shape = (self.N_particles, self._N_cols)
             # Forward field
             self.inv_Bz_array = np.matmul(self.Q,

--- a/mmt_multipole_inversion/multipole_inversion.py
+++ b/mmt_multipole_inversion/multipole_inversion.py
@@ -379,12 +379,13 @@ class MultipoleInversion(object):
                     print('Generating forward matrix')
                 self.generate_forward_matrix()
             Bz_Data = np.reshape(self.Bz_array, self.N_sensors, order='C')
+            if self.verbose:
+                print('Using direct inversion')
             self.inv_multipole_moments, res, rnk, s = slin.lstsq(self.Q, Bz_Data)
             self.inv_multipole_moments.shape = (self.N_particles, self._N_cols)
             # Forward field
             self.inv_Bz_array = np.matmul(self.Q,
-                                           self.inv_multipole_moments.reshape(
-                                               -1))
+                                          self.inv_multipole_moments.reshape(-1))
             self.inv_Bz_array.shape = (self.Ny_surf, self.Nx_surf)
         else:
             if method == 'np_pinv':


### PR DESCRIPTION
Direct inverse allows computation of the magnetic moments without the explicit inverse matrix, saving time and memory space. 
 This option has a separate test in test_inversion.py. Errors are of the same size as the sp_pinv option.